### PR TITLE
fix nil pointer on unknown field

### DIFF
--- a/query.go
+++ b/query.go
@@ -78,7 +78,11 @@ func (d *gormLike) queryCallback(db *gorm.DB) {
 			}
 
 			// Get the `gormlike` value
-			tagValue := db.Statement.Schema.FieldsByDBName[columnName].Tag.Get(tagName)
+			var tagValue string
+			dbField, ok := db.Statement.Schema.FieldsByDBName[columnName]
+			if ok {
+				tagValue = dbField.Tag.Get(tagName)
+			}
 
 			// If the user has explicitly set this to false, ignore this field
 			if tagValue == "false" {

--- a/query.go
+++ b/query.go
@@ -38,7 +38,11 @@ func (d *gormLike) queryCallback(db *gorm.DB) {
 			}
 
 			// Get the `gormlike` value
-			tagValue := db.Statement.Schema.FieldsByDBName[columnName].Tag.Get(tagName)
+			var tagValue string
+			dbField, ok := db.Statement.Schema.FieldsByDBName[columnName]
+			if ok {
+				tagValue = dbField.Tag.Get(tagName)
+			}
 
 			// If the user has explicitly set this to false, ignore this field
 			if tagValue == "false" {


### PR DESCRIPTION
Fixes possible nil-pointer on unknown fields when used in conjunction with `https://github.com/survivorbat/gorm-deep-filtering`